### PR TITLE
Ignore coredumps from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bwbench-*
 /build
+/core
 .clangd
 dat
 plots


### PR DESCRIPTION
Coredumps do not belong into the repository.